### PR TITLE
Changed fault details object serializer, and added xml atributes in DTO

### DIFF
--- a/src/SoapCore.Tests/Model/FaultDetail.cs
+++ b/src/SoapCore.Tests/Model/FaultDetail.cs
@@ -1,11 +1,16 @@
 using System.Runtime.Serialization;
+using System.Xml.Serialization;
+using SoapCore.Tests.Serialization.Models.Xml;
 
 namespace SoapCore.Tests.Model
 {
 	[DataContract]
+	[XmlRoot(Namespace = ServiceNamespace.Value + "FaultDetail")]
+	[XmlType(Namespace = ServiceNamespace.Value + "FaultDetail")]
 	public class FaultDetail
 	{
 		[DataMember]
+		[XmlElement(Namespace = ServiceNamespace.Value + "ExceptionDetails")]
 		public string ExceptionProperty { get; set; }
 	}
 }

--- a/src/SoapCore/Fault.cs
+++ b/src/SoapCore/Fault.cs
@@ -36,8 +36,7 @@ namespace SoapCore
 
 			using (var ms = new MemoryStream())
 			{
-				var serializer = new DataContractSerializer(detailObject.GetType());
-				serializer.WriteObject(ms, detailObject);
+				new XmlSerializer(detailObject.GetType()).Serialize(ms, detailObject);
 				ms.Position = 0;
 				var doc = new XmlDocument();
 				doc.Load(ms);


### PR DESCRIPTION
Fix works as expected from output data but suddenly UnitTests stopped working. Somehow serialization process impacted expected FaultException type!